### PR TITLE
docs(misc): add note to enable firebase auth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ To use this project with Firebase, some configuration steps are required.
 - then, [download and copy](https://firebase.google.com/docs/flutter/setup#configure_an_android_app) `google-services.json` into `android/app`.
 - On iOS, use `com.example.starterArchitectureFlutterFirebase` as the bundle ID.
 - then, [download and copy](https://firebase.google.com/docs/flutter/setup#configure_an_ios_app) `GoogleService-Info.plist` into `iOS/Runner`, and add it to the Runner target in Xcode.
+- finally, enable the Email/Password Authentication Sign-in provider in the Firebase Console (Authentication > Sign-in method > Email/Password > Edit > Enable > Save)
 
 See this page for full instructions:
 


### PR DESCRIPTION
this will prevent a CONFIGURATION_NOT_FOUND exception when attempting
any sign-in methods