### PR TITLE
Adding an extra step to show the customizable loading widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,11 +5,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:starter_architecture_flutter_firebase/firebase_options.dart';
 import 'package:starter_architecture_flutter_firebase/src/app.dart';
 import 'package:starter_architecture_flutter_firebase/src/localization/string_hardcoded.dart';
+import 'package:starter_architecture_flutter_firebase/src/routing/app_startup.dart';
+
 // ignore:depend_on_referenced_packages
 import 'package:flutter_web_plugins/url_strategy.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  
+  runApp(
+    const MaterialApp(
+        home: AppStartupLoadingWidget(),
+    ),
+  );
+
+  
   // turn off the # in the URLs on the web
   usePathUrlStrategy();
   // * Register error handlers. For more info, see:


### PR DESCRIPTION
By calling the `runApp` twice we can show our custom loading widget while the app is being initialized in the `main' with the benefits of supporting Deep Links as:
```dart
Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();

  
  runApp(
    const MaterialApp(
        home: AppStartupLoadingWidget(),
    ),
  );

  
  // turn off the # in the URLs on the web
  usePathUrlStrategy();
  // * Register error handlers. For more info, see:
  // * https://docs.flutter.dev/testing/errors
  registerErrorHandlers();
  // * Initialize Firebase
  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
  // * Entry point of the app
  runApp(const ProviderScope(
    child: MyApp(),
  ));
}
``` 

And according to Flutter documentation, it says 
```dart
/// Calling [runApp] again will detach the previous root widget from the screen
/// and attach the given widget in its place. The new widget tree is compared
/// against the previous widget tree and any differences are applied to the
/// underlying render tree, similar to what happens when a [StatefulWidget]
/// rebuilds after calling [State.setState].
``` 

credits to: https://github.com/flutter/flutter/issues/6818