### PR TITLE
Add GoRouterDelegateListener class to track screen views

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:force_update_helper/force_update_helper.dart';
 import 'package:starter_architecture_flutter_firebase/src/routing/app_router.dart';
 import 'package:starter_architecture_flutter_firebase/src/routing/app_startup.dart';
+import 'package:starter_architecture_flutter_firebase/src/routing/go_router_delegate_listener.dart';
 import 'package:starter_architecture_flutter_firebase/src/utils/alert_dialogs.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -56,7 +57,7 @@ class MyApp extends ConsumerWidget {
             onException: (e, st) {
               log(e.toString());
             },
-            child: child!,
+            child: GoRouterDelegateListener(child: child!),
           ),
         );
       },

--- a/lib/src/routing/app_router.dart
+++ b/lib/src/routing/app_router.dart
@@ -46,7 +46,7 @@ GoRouter goRouter(Ref ref) {
   return GoRouter(
     initialLocation: '/signIn',
     navigatorKey: _rootNavigatorKey,
-    debugLogDiagnostics: true,
+    //debugLogDiagnostics: true,
     redirect: (context, state) {
       final onboardingRepository =
           ref.read(onboardingRepositoryProvider).requireValue;

--- a/lib/src/routing/go_router_delegate_listener.dart
+++ b/lib/src/routing/go_router_delegate_listener.dart
@@ -16,7 +16,8 @@ class GoRouterDelegateListener extends ConsumerStatefulWidget {
 }
 
 class _GoRouterListenerState extends ConsumerState<GoRouterDelegateListener> {
-  // Helper getter for the GoRouter instance
+  /// Helper variable for retrieving the GoRouter delegate
+  /// Note: using GoRouter.of(context) throws an exception so we use the goRouterProvider instead
   late final routerDelegate = ref.read(goRouterProvider).routerDelegate;
 
   @override

--- a/lib/src/routing/go_router_delegate_listener.dart
+++ b/lib/src/routing/go_router_delegate_listener.dart
@@ -1,0 +1,48 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:starter_architecture_flutter_firebase/src/routing/app_router.dart';
+
+// Listener widget to track screen views. Adapted from:
+// https://github.com/flutter/flutter/issues/112196#issuecomment-1680382232
+class GoRouterDelegateListener extends ConsumerStatefulWidget {
+  const GoRouterDelegateListener({super.key, required this.child});
+  final Widget child;
+
+  @override
+  ConsumerState<GoRouterDelegateListener> createState() =>
+      _GoRouterListenerState();
+}
+
+class _GoRouterListenerState extends ConsumerState<GoRouterDelegateListener> {
+  // Helper getter for the GoRouter instance
+  late final routerDelegate = ref.read(goRouterProvider).routerDelegate;
+
+  @override
+  void initState() {
+    super.initState();
+    routerDelegate.addListener(_listener);
+  }
+
+  @override
+  void dispose() {
+    routerDelegate.removeListener(_listener);
+    super.dispose();
+  }
+
+  void _listener() {
+    final config = routerDelegate.currentConfiguration;
+    final screenName = config.last.route.name;
+    if (screenName != null) {
+      final pathParams = config.pathParameters;
+      // TODO: Add your own logging or analytics screen tracking code
+      log('screenName: $screenName, pathParams: $pathParams');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}


### PR DESCRIPTION
Replaces #160 by implementing a workaround for this issue:

- [[go_router] ShellRoutes seem to cause NavigatorObserver to not fire (5.0.1)](https://github.com/flutter/flutter/issues/112196)

Workaround is based on this comment:

https://github.com/flutter/flutter/issues/112196#issuecomment-1680382232

Example log while navigating the app:

```
[log] screenName: signIn, pathParams: {}
[log] screenName: jobs, pathParams: {}
[log] screenName: job, pathParams: {id: 6NDSdYl00ZSDTbfY1zoX}
[log] screenName: jobs, pathParams: {}
[log] screenName: entries, pathParams: {}
[log] screenName: profile, pathParams: {}
```