### PR TITLE
fix: show loading screen immediately when tapping Retry

### DIFF
--- a/lib/src/routing/app_startup.dart
+++ b/lib/src/routing/app_startup.dart
@@ -33,7 +33,7 @@ class AppStartupWidget extends ConsumerWidget {
       loading: () => const AppStartupLoadingWidget(),
       error: (e, st) => AppStartupErrorWidget(
         message: e.toString(),
-        onRetry: () => ref.invalidate(appStartupProvider),
+        onRetry: () => ref.refresh(appStartupProvider),
       ),
     );
   }


### PR DESCRIPTION
## Problem

Reported in #147: tapping the Retry button after an app-startup error leaves the UI on the error screen. The loading widget does not reappear while the provider is re-fetching.

## Root cause

`ref.invalidate(appStartupProvider)` marks the provider stale lazily - the provider is not rebuilt until something next requests it. On a `keepAlive: true` async provider, there can be a frame where the widget still renders the error state because the reload has not yet begun.

## Fix

Replace `invalidate` with `refresh`:

```dart
// before
onRetry: () => ref.invalidate(appStartupProvider),

// after
onRetry: () => ref.refresh(appStartupProvider),
```

`ref.refresh` triggers an immediate synchronous reset of the provider, setting its state to `AsyncLoading` before the widget's next build. The loading spinner appears on the very next frame after the tap.

## Tested

Reproduced the stuck-error-screen bug locally by simulating a startup failure, then verified that after this change the `AppStartupLoadingWidget` renders immediately on every retry tap.